### PR TITLE
Add capi-appfw packages

### DIFF
--- a/sysroot/build-rootfs.py
+++ b/sysroot/build-rootfs.py
@@ -22,6 +22,12 @@ basePackages = [
     'zlib-devel',
 ]
 unifiedPackages = [
+    'capi-appfw-application',
+    'capi-appfw-application-devel',
+    'capi-appfw-app-common',
+    'capi-appfw-app-common-devel',
+    'capi-appfw-app-control',
+    'capi-appfw-app-control-devel',
     'capi-base-common-devel',
     'capi-base-utils',
     'capi-base-utils-devel',


### PR DESCRIPTION
When Tizen shell handle 'SystemNavigator.pop', need exit application.
Tizen shell need call Tizen system exit app interface, notify app
shutdown flutter engine and destory window. ui_app_exit() belongs
to capi-appfw packages.