### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,36 +67,13 @@ cp -r $TIZEN_STUDIO/tools/i586-linux-gnueabi-gcc-9.2/lib/gcc/i586-tizen-linux-gn
 
 Run `build-rootfs.py` to generate a sysroot for each target architecture. You have to re-generate the sysroot whenever this repo has been updated.
 
-<details open>
-<summary>For arm (Tizen 5.5+)</summary><p>
-
 ```sh
+# For arm
 sysroot/build-rootfs.py --arch arm
-```
 
-</details>
-
-<details>
-<summary>For different architectures (optional)</summary><p>
-
-```sh
-# For arm64 (Tizen 5.5+)
+# For arm64 (optional)
 sysroot/build-rootfs.py --arch arm64
 
-# For x86 (Tizen 5.5+)
+# For x86 (optional)
 sysroot/build-rootfs.py --arch x86
-
-# For arm (Tizen 4.0)
-sysroot/build-rootfs.py --arch arm \
---base-repo http://download.tizen.org/snapshots/tizen/4.0-base/latest/repos/arm/packages \
---unified-repo http://download.tizen.org/snapshots/tizen/4.0-unified/latest/repos/standard/packages \
---output arm_40
-
-# For x86 (Tizen 4.0)
-sysroot/build-rootfs.py --arch x86 \
---base-repo http://download.tizen.org/snapshots/tizen/4.0-base/latest/repos/emulator32/packages \
---unified-repo http://download.tizen.org/snapshots/tizen/4.0-unified/latest/repos/standard/packages \
---output x86_40
 ```
-
-</details>


### PR DESCRIPTION
We no longer need to build the engine separately for Tizen 4.0. (https://github.com/flutter-tizen/flutter-tizen/issues/86)