### PR TITLE
Add capi-appfw-app-manager dependencies

### DIFF
--- a/sysroot/build-rootfs.py
+++ b/sysroot/build-rootfs.py
@@ -29,6 +29,8 @@ unifiedPackages = [
     'capi-appfw-app-common-devel',
     'capi-appfw-app-control',
     'capi-appfw-app-control-devel',
+    'capi-appfw-app-manager',
+    'capi-appfw-app-manager-devel',
     'capi-base-common',
     'capi-base-common-devel',
     'capi-base-utils',


### PR DESCRIPTION
To resolve https://github.com/flutter-tizen/flutter-tizen/issues/216.