### PR TITLE
Use custom build of LLVM 14

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
 
 jobs:
   build:
@@ -20,7 +21,5 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: .
-        file: ./Dockerfile
         push: true
-        tags: |
-          ghcr.io/${{ github.repository_owner }}/tizen-tools:latest
+        tags: ghcr.io/${{ github.repository_owner }}/tizen-tools:latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 toolchains/
+llvm-project/
 sysroot/arm*/
 sysroot/x86*/

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,9 +46,8 @@ FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Install packages for engine build.
 RUN apt-get update && \
-    apt-get install -y git curl ca-certificates python && \
+    apt-get install -y binutils-arm-linux-gnueabi binutils-aarch64-linux-gnu binutils-i686-linux-gnu && \
     apt-get clean
 
 # Copy build results from previous stages.

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,29 +10,9 @@ RUN apt-get update && \
     apt-get install -y git zip build-essential cmake ninja-build clang-11 && \
     apt-get clean
 
-# Download the LLVM project source code.
-RUN git clone --depth=1 --branch=llvmorg-14.0.1 https://github.com/llvm/llvm-project.git
-WORKDIR llvm-project/build
+COPY build-llvm.sh .
 
-# Run the ninja build.
-RUN cmake -G Ninja \
-    -DCLANG_VENDOR="Tizen" \
-    -DLLVM_ENABLE_PROJECTS="clang" \
-    -DLLVM_TARGETS_TO_BUILD="X86;ARM;AArch64" \
-    -DCMAKE_C_COMPILER=clang-11 \
-    -DCMAKE_CXX_COMPILER=clang++-11 \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_INSTALL_PREFIX=/llvm \
-    ../llvm
-RUN ninja && ninja install
-
-# Create symbolic links to binutils.
-WORKDIR /llvm/bin
-RUN for name in ar readelf nm strip; do \
-      ln -s llvm-$name arm-linux-gnueabi-$name; \
-      ln -s llvm-$name aarch64-linux-gnu-$name; \
-      ln -s llvm-$name i686-linux-gnu-$name; \
-    done
+RUN /build-llvm.sh
 
 
 ######################################
@@ -54,13 +34,13 @@ RUN /sysroot/build-rootfs.py --arch arm
 RUN /sysroot/build-rootfs.py --arch arm64
 RUN /sysroot/build-rootfs.py --arch x86
 
-# Remove cached RPM packages.
+# Remove cached packages.
 RUN rm -r /sysroot/*/.rpms
 
 
-###############################
-### Produce a release image ###
-###############################
+##############################
+### Create a release image ###
+##############################
 
 FROM ubuntu:20.04
 
@@ -72,5 +52,5 @@ RUN apt-get update && \
     apt-get clean
 
 # Copy build results from previous stages.
-COPY --from=llvm /llvm/ /tizen_tools/toolchains/
+COPY --from=llvm /toolchains/ /tizen_tools/toolchains/
 COPY --from=sysroot /sysroot/ /tizen_tools/sysroot/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,76 +1,66 @@
-########################################
-### Stage for toolchains and sysroot ###
-########################################
+###############################
+### Stage for building LLVM ###
+###############################
 
-FROM ubuntu:20.04 AS builder
+FROM ubuntu:20.04 AS llvm
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update
-RUN apt-get install -y git curl rpm2cpio cpio zip pciutils libncurses5 libpython2.7 python2.7 python3
-RUN apt-get clean
+RUN apt-get update && \
+    apt-get install -y git zip build-essential cmake ninja-build clang-11 && \
+    apt-get clean
 
-# Only non-root users can install Tizen Studio.
-RUN useradd -ms /bin/bash user
-USER user
-WORKDIR /home/user
+# Download the LLVM project source code.
+RUN git clone --depth=1 --branch=llvmorg-14.0.1 https://github.com/llvm/llvm-project.git
+WORKDIR llvm-project/build
 
-# Install Tizen Studio
-ENV TIZEN_STUDIO=/home/user/tizen-studio
-RUN curl -o installer.bin http://download.tizen.org/sdk/Installer/tizen-studio_4.1.1/web-cli_Tizen_Studio_4.1.1_ubuntu-64.bin
-RUN chmod a+x installer.bin
-RUN ./installer.bin --accept-license ${TIZEN_STUDIO}
-RUN ${TIZEN_STUDIO}/package-manager/package-manager-cli.bin install NativeToolchain-Gcc-9.2
+# Run the ninja build.
+RUN cmake -G Ninja \
+    -DCLANG_VENDOR="Tizen" \
+    -DLLVM_ENABLE_PROJECTS="clang" \
+    -DLLVM_TARGETS_TO_BUILD="X86;ARM;AArch64" \
+    -DCMAKE_C_COMPILER=clang-11 \
+    -DCMAKE_CXX_COMPILER=clang++-11 \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=/llvm \
+    ../llvm
+RUN ninja && ninja install
 
-# Create tizen_tools directory first to grant privileges to user.
-ENV TIZEN_TOOLS=/home/user/tizen_tools
-RUN mkdir -p ${TIZEN_TOOLS}
-WORKDIR ${TIZEN_TOOLS}
-
-# Prepare for copying.
-ENV TOOLCHAINS_PATH=${TIZEN_TOOLS}/toolchains
-RUN mkdir -p ${TOOLCHAINS_PATH}
-ENV SYSROOT_PATH=${TIZEN_TOOLS}/sysroot
-RUN mkdir -p ${SYSROOT_PATH}
-
-# Copy toolchains.
-SHELL ["/bin/bash", "-c"]
-RUN mkdir -p ${TOOLCHAINS_PATH}/bin
-RUN for f in ${TIZEN_STUDIO}/tools/arm-linux-gnueabi-gcc-9.2/bin/arm-linux-*; do \
-    b=$(basename $f); \
-    cp $f ${TOOLCHAINS_PATH}/bin/armv7l-tizen-${b:4}; \
-    done
-RUN for f in ${TIZEN_STUDIO}/tools/aarch64-linux-gnu-gcc-9.2/bin/aarch64-linux-*; do \
-    b=$(basename $f); \
-    cp $f ${TOOLCHAINS_PATH}/bin/aarch64-tizen-${b:8}; \
-    done
-RUN for f in ${TIZEN_STUDIO}/tools/i586-linux-gnueabi-gcc-9.2/bin/i586-linux-*; do \
-    b=$(basename $f); \
-    cp $f ${TOOLCHAINS_PATH}/bin/i586-tizen-${b:5}; \
+# Create symbolic links to binutils.
+WORKDIR /llvm/bin
+RUN for name in ar readelf nm strip; do \
+      ln -s llvm-$name arm-linux-gnueabi-$name; \
+      ln -s llvm-$name aarch64-linux-gnu-$name; \
+      ln -s llvm-$name i686-linux-gnu-$name; \
     done
 
-# FIXME: https://github.com/flutter-tizen/tizen_tools/pull/7#discussion_r611339789
-RUN ln -s aarch64-tizen-linux-gnu-ld ${TOOLCHAINS_PATH}/bin/ld
 
-# FIXME: This should not be necessary.
-RUN mkdir -p ${SYSROOT_PATH}/arm64/usr/lib
-RUN cp -r ${TIZEN_STUDIO}/tools/aarch64-linux-gnu-gcc-9.2/lib/gcc/aarch64-tizen-linux-gnu/9.2.0/*.{o,a} ${SYSROOT_PATH}/arm64/usr/lib
+######################################
+### Stage for constructing sysroot ###
+######################################
 
-# FIXME: This should not be necessary.
-RUN mkdir -p ${TOOLCHAINS_PATH}/lib/gcc
-RUN cp -r ${TIZEN_STUDIO}/tools/i586-linux-gnueabi-gcc-9.2/lib/gcc/i586-tizen-linux-gnueabi ${TOOLCHAINS_PATH}/lib/gcc
+FROM ubuntu:20.04 AS sysroot
 
-# Construct sysroots.
-COPY sysroot/build-rootfs.py ${SYSROOT_PATH}
-COPY sysroot/*.patch ${SYSROOT_PATH}
-RUN ${SYSROOT_PATH}/build-rootfs.py --arch arm
-RUN ${SYSROOT_PATH}/build-rootfs.py --arch arm64
-RUN ${SYSROOT_PATH}/build-rootfs.py --arch x86
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y python3 rpm2cpio cpio git && \
+    apt-get clean
+
+COPY sysroot/build-rootfs.py /sysroot/
+COPY sysroot/*.patch /sysroot/
+
+RUN /sysroot/build-rootfs.py --arch arm
+RUN /sysroot/build-rootfs.py --arch arm64
+RUN /sysroot/build-rootfs.py --arch x86
+
+# Remove cached RPM packages.
+RUN rm -r /sysroot/*/.rpms
 
 
-#############################
-### Image for tizen-tools ###
-#############################
+###############################
+### Produce a release image ###
+###############################
 
 FROM ubuntu:20.04
 
@@ -81,7 +71,6 @@ RUN apt-get update && \
     apt-get install -y git curl ca-certificates python && \
     apt-get clean
 
-# Copy tizen_tools from the previous stage.
-COPY --from=builder /home/user/tizen-studio/tools/llvm-10/  /tizen_tools/toolchains/
-COPY --from=builder /home/user/tizen_tools/toolchains/  /tizen_tools/toolchains/
-COPY --from=builder /home/user/tizen_tools/sysroot/  /tizen_tools/sysroot/
+# Copy build results from previous stages.
+COPY --from=llvm /llvm/ /tizen_tools/toolchains/
+COPY --from=sysroot /sysroot/ /tizen_tools/sysroot/

--- a/README.md
+++ b/README.md
@@ -2,78 +2,84 @@
 
 Tizen cross-compilation toolchain for building the Flutter engine.
 
-## Generating toolchains
+## Installing the toolchain
 
-You need a Linux x64 host with [Tizen Studio](https://developer.tizen.org/development/tizen-studio/download) 4.0 or later installed. It is assumed that `tizen-studio` is installed in the default location (_HOME_), and the required package (_NativeToolchain-Gcc-9.2_) is already installed. Run the following commands in this directory to copy required files from `tizen-studio` to `toolchains`. Typically, you have to run this only once.
+You need a Linux x64 host to build the Flutter engine for Tizen devices.
+
+### Building the toolchain from source (recommended)
+
+Run the following commands to build LLVM 14 from source.
 
 ```sh
-TIZEN_STUDIO=$HOME/tizen-studio
+# Install prerequisites. We use ninja and Clang 11 for the build.
+sudo apt update
+sudo apt install git zip build-essential cmake ninja-build clang-11
 
-mkdir -p toolchains
-cp -r $TIZEN_STUDIO/tools/llvm-10/* toolchains
+# Run the build script.
+./build-llvm.sh
 ```
 
-<details open>
-<summary>For arm</summary><p>
+### Using Tizen Studio's built-in toolchain (deprecated)
+
+Run the following commands in this directory. We assume that [Tizen Studio](https://developer.tizen.org/development/tizen-studio/download) is already installed to the default location (_$HOME_) on your local drive. The required package (_NativeToolchain-Gcc-9.2_) must also be installed.
+
+<details><p>
 
 ```sh
-for f in $TIZEN_STUDIO/tools/arm-linux-gnueabi-gcc-9.2/bin/arm-linux-*; do
+rm -rf toolchains && mkdir -p toolchains
+cp -r ~/tizen-studio/tools/llvm-10/* toolchains
+
+# For arm.
+cp ~/tizen-studio/tools/arm-linux-gnueabi-gcc-9.2/bin/arm-linux-gnueabi-* toolchains/bin
+
+# For arm64.
+cp ~/tizen-studio/tools/aarch64-linux-gnu-gcc-9.2/bin/aarch64-linux-gnu-* toolchains/bin
+
+# For x86.
+for f in ~/tizen-studio/tools/i586-linux-gnueabi-gcc-9.2/bin/i586-linux-gnueabi-*; do
   b=`basename $f`
-  cp $f toolchains/bin/armv7l-tizen-${b:4}
+  cp $f toolchains/bin/i686-linux-gnu-${b:19}
 done
+```
+
+The toolchain shipped with Tizen Studio (LLVM 10) is pretty old. You need to disable the following unsupported compile options before running the engine build.
+
+```patch
+--- a/build/config/compiler/BUILD.gn
++++ b/build/config/compiler/BUILD.gn
+@@ -617,17 +617,13 @@ if (is_win) {
+
+  if (!use_xcode) {
+    default_warning_flags += [
+-      "-Wno-unused-but-set-parameter",
+-      "-Wno-unused-but-set-variable",
+      "-Wno-implicit-int-float-conversion",
+      "-Wno-c99-designator",
+      "-Wno-deprecated-copy",
+      # Needed for compiling Skia with clang-12
+-      "-Wno-psabi",
+    ]
+    if (!is_fuchsia) {
+      default_warning_flags += [
+-        "-Wno-non-c-typedef-for-linkage",
+        "-Wno-range-loop-construct",
+      ]
+    }
 ```
 
 </details>
 
-<details>
-<summary>For arm64 (optional)</summary><p>
+## Constructing a sysroot
 
-Make sure you already have created a sysroot for arm64 (below) before running the following.
-
-```sh
-for f in $TIZEN_STUDIO/tools/aarch64-linux-gnu-gcc-9.2/bin/aarch64-linux-*; do
-  b=`basename $f`
-  cp $f toolchains/bin/aarch64-tizen-${b:8}
-done
-
-# FIXME: https://github.com/flutter-tizen/tizen_tools/pull/7#discussion_r611339789
-ln -s aarch64-tizen-linux-gnu-ld toolchains/bin/ld
-
-# FIXME: This should not be necessary.
-cp -r $TIZEN_STUDIO/tools/aarch64-linux-gnu-gcc-9.2/lib/gcc/aarch64-tizen-linux-gnu/9.2.0/*.{o,a} \
-  sysroot/arm64/usr/lib
-```
-
-</details>
-
-<details>
-<summary>For x86 (optional)</summary><p>
+Run `build-rootfs.py` to generate a sysroot for each target architecture. You have to re-run the command whenever this repo is updated.
 
 ```sh
-for f in $TIZEN_STUDIO/tools/i586-linux-gnueabi-gcc-9.2/bin/i586-linux-*; do
-  b=`basename $f`
-  cp $f toolchains/bin/i586-tizen-${b:5}
-done
-
-# FIXME: This should not be necessary.
-mkdir -p toolchains/lib/gcc
-cp -r $TIZEN_STUDIO/tools/i586-linux-gnueabi-gcc-9.2/lib/gcc/i586-tizen-linux-gnueabi \
-  toolchains/lib/gcc
-```
-
-</details>
-
-## Generating a sysroot
-
-Run `build-rootfs.py` to generate a sysroot for each target architecture. You have to re-generate the sysroot whenever this repo has been updated.
-
-```sh
-# For arm
+# For arm.
 sysroot/build-rootfs.py --arch arm
 
-# For arm64 (optional)
+# For arm64.
 sysroot/build-rootfs.py --arch arm64
 
-# For x86 (optional)
+# For x86.
 sysroot/build-rootfs.py --arch x86
 ```

--- a/README.md
+++ b/README.md
@@ -11,12 +11,15 @@ You need a Linux x64 host to build the Flutter engine for Tizen devices.
 Run the following commands to build LLVM 14 from source.
 
 ```sh
-# Install prerequisites. We use ninja and Clang 11 for the build.
+# Install prerequisites for build. We use ninja and clang-11 for the build.
 sudo apt update
 sudo apt install git zip build-essential cmake ninja-build clang-11
 
 # Run the build script.
 ./build-llvm.sh
+
+# Install extra packages required by the linker.
+sudo apt install binutils-arm-linux-gnueabi binutils-aarch64-linux-gnu binutils-i686-linux-gnu
 ```
 
 ### Using Tizen Studio's built-in toolchain (deprecated)

--- a/build-llvm.sh
+++ b/build-llvm.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Copyright 2022 Samsung Electronics Co., Ltd. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+set -e
+
+SCRIPT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+OUTPUT_DIR="$SCRIPT_DIR/toolchains"
+cd "$SCRIPT_DIR"
+
+# Check out the LLVM project source code.
+if [ -d llvm-project ]; then
+  echo "The directory already exists. Skipping download."
+else
+  git clone --depth=1 --branch=llvmorg-14.0.1 https://github.com/llvm/llvm-project.git
+fi
+cd llvm-project
+
+# Run the ninja build.
+mkdir -p build && cd build
+cmake -G Ninja \
+  -DCLANG_VENDOR="Tizen" \
+  -DLLVM_ENABLE_PROJECTS="clang" \
+  -DLLVM_TARGETS_TO_BUILD="X86;ARM;AArch64" \
+  -DCMAKE_C_COMPILER=clang-11 \
+  -DCMAKE_CXX_COMPILER=clang++-11 \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX="$OUTPUT_DIR" \
+  ../llvm
+ninja
+ninja install
+
+# Create symbolic links to binutils.
+# For details, see build/toolchain/custom/BUILD.gn in the buildroot.
+cd "$OUTPUT_DIR/bin"
+for name in ar readelf nm strip; do
+  ln -sf llvm-$name arm-linux-gnueabi-$name
+  ln -sf llvm-$name aarch64-linux-gnu-$name
+  ln -sf llvm-$name i686-linux-gnu-$name
+done

--- a/build-llvm.sh
+++ b/build-llvm.sh
@@ -28,7 +28,6 @@ cmake -G Ninja \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_INSTALL_PREFIX="$OUTPUT_DIR" \
   ../llvm
-ninja
 ninja install
 
 # Create symbolic links to binutils.

--- a/sysroot/build-rootfs.py
+++ b/sysroot/build-rootfs.py
@@ -118,7 +118,7 @@ if __name__ != "__main__":
 # Check dependencies.
 for dep in ['rpm2cpio', 'cpio', 'git']:
     if not shutil.which(dep):
-        sys.exit(f'{dep} is not install. To install, run:\n'
+        sys.exit(f'{dep} is not installed. To install, run:\n'
                  f'  sudo apt install {dep}')
 
 # Parse arguments.
@@ -207,7 +207,7 @@ if not os.path.exists(f'{outpath}/usr/include/asm'):
 if args.arch == 'arm64' and not os.path.exists(f'{outpath}/usr/lib/pkgconfig'):
     os.symlink(f'../lib64/pkgconfig', f'{outpath}/usr/lib/pkgconfig')
 
-# Copy objects required by linker, such as crtbeginS.o and libgcc.a.
+# Copy objects required by the linker, such as crtbeginS.o and libgcc.a.
 if args.arch == 'arm64':
     libpath = f'{outpath}/usr/lib64'
 else:

--- a/sysroot/build-rootfs.py
+++ b/sysroot/build-rootfs.py
@@ -108,7 +108,7 @@ unifiedPackages = [
     'xdgmime',
     'xdgmime-devel',
     'wayland-extension-client-devel',
-    'wayland-devel'
+    'wayland-devel',
 ]
 
 # Execute only if run as a script.

--- a/sysroot/build-rootfs.py
+++ b/sysroot/build-rootfs.py
@@ -8,6 +8,7 @@ import os
 import re
 import shutil
 import subprocess
+import sys
 import urllib.parse
 import urllib.request
 
@@ -107,21 +108,18 @@ unifiedPackages = [
     'xdgmime',
     'xdgmime-devel',
     'wayland-extension-client-devel',
-    'wayland-devel',
+    'wayland-devel'
 ]
 
 # Execute only if run as a script.
 if __name__ != "__main__":
-    exit(1)
+    sys.exit()
 
-if not shutil.which('rpm2cpio'):
-    print('rpm2cpio is not installed. To install:\n'
-          '  sudo apt install rpm2cpio')
-    exit(1)
-if not shutil.which('cpio'):
-    print('cpio is not installed. To install:\n'
-          '  sudo apt install cpio')
-    exit(1)
+# Check dependencies.
+for dep in ['rpm2cpio', 'cpio', 'git']:
+    if not shutil.which(dep):
+        sys.exit(f'{dep} is not install. To install, run:\n'
+                 f'  sudo apt install {dep}')
 
 # Parse arguments.
 parser = argparse.ArgumentParser(
@@ -150,7 +148,7 @@ if not args.output:
     args.output = args.arch
 outpath = os.path.abspath(f'{__file__}/../{args.output}')
 
-if args.clean:
+if args.clean and os.path.exists(outpath):
     shutil.rmtree(outpath)
 
 downloadPath = os.path.join(outpath, '.rpms')
@@ -164,8 +162,7 @@ elif args.arch == 'arm64':
 elif args.arch == 'x86':
     archName = 'i686'
 else:
-    print(f'Undefined arch: {args.arch}')
-    exit(1)
+    sys.exit(f'Undefined arch: {args.arch}')
 
 # Retrieve html documents.
 documents = {}
@@ -193,7 +190,7 @@ for package in basePackages + unifiedPackages:
             break
 
     if len(match) == 0:
-        print(f'Could not find a package {package}')
+        sys.exit(f'Could not find a package {package}')
     else:
         print(f'Downloading {url}...')
         urllib.request.urlretrieve(url, f'{downloadPath}/{match[0]}')
@@ -209,6 +206,14 @@ if not os.path.exists(f'{outpath}/usr/include/asm'):
     os.symlink(f'asm-{args.arch}', f'{outpath}/usr/include/asm')
 if args.arch == 'arm64' and not os.path.exists(f'{outpath}/usr/lib/pkgconfig'):
     os.symlink(f'../lib64/pkgconfig', f'{outpath}/usr/lib/pkgconfig')
+
+# Copy objects required by linker, such as crtbeginS.o and libgcc.a.
+if args.arch == 'arm64':
+    libpath = f'{outpath}/usr/lib64'
+else:
+    libpath = f'{outpath}/usr/lib'
+subprocess.run(
+    f'cd {libpath} && cp gcc/*/*/*.o gcc/*/*/*.a .', shell=True, check=True)
 
 # Apply a patch if applicable.
 patchFile = os.path.abspath(f'{__file__}/../{args.arch}.patch')


### PR DESCRIPTION
Part of https://github.com/flutter-tizen/engine/issues/271.

- Add a build script `build-llvm.sh`.
  - We don't use Tizen Studio's old LLVM 10 any more. Instead, let users build the latest stable version of LLVM from source.
  - The users do not have to [manually disable unsupported compile options](https://github.com/flutter-tizen/flutter-tizen/wiki/Building-the-engine-from-source#setting-up-the-build-environment) any more.
- Add a stage for building LLVM to the Dockerfile.
  - Remove all workarounds (FIXME) in the Dockerfile.
- Update `build-rootfs.py`.
  - Automatically copy missing files required by the linker (`ld`). For example,<p>
    ```sh
    sysroot/arm/usr/lib/gcc/armv7l-tizen-linux-gnueabi/6.2.1/crtbeginS.o -> sysroot/arm/usr/lib/crtbeginS.o
    ```
  - Add `git` to dependencies.
  - Fail fast if a target package is not found.
- Update README.

I also considered several other ways:

- (a) Use pre-built LLVM 14 downloaded from the apt repository.
  - x86 build fails. (Error: `... compiled without support for 'sse2'`)
  - ~arm unit test build fails. (Error: `undefined reference to 'fcntl64'`)~
  - ~The output binaries depend on a too high version of glibc (2.29).~
- (b) Release our own build of LLVM (which can be downloaded via `gclient sync`).
  - We don't have a storage server to do this. The total size of the artifacts is over 2 GB and they contain large files (>100 MB) that cannot be uploaded to GitHub.
- (c) Let the user download and use the [tizen_tools](https://github.com/flutter-tizen/tizen_tools/pkgs/container/tizen-tools) Docker image to build the engine.
  - This complicates things too much.

The engine side PR: https://github.com/flutter-tizen/engine/pull/276