### PR TITLE
[docker] Build tizen-headed-armv7l image

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -7,19 +7,41 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  builder:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: docker/setup-buildx-action@v1
-    - uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-    - name: Build and push
-      uses: docker/build-push-action@v2
-      with:
-        context: .
-        push: true
-        tags: ghcr.io/${{ github.repository_owner }}/tizen-tools:latest
+      - uses: actions/checkout@v3
+      - uses: docker/setup-buildx-action@v2
+      - uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/tizen-tools:latest
+
+  testbed:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        env:
+          REPO_URL: http://download.tizen.org/releases/milestone/tizen/unified
+          BUILD_ID: tizen-unified_20220517.1
+          IMAGE: tizen-headed-armv7l
+        run: |
+          wget -q ${REPO_URL}/${BUILD_ID}/images/standard/${IMAGE}/${BUILD_ID}_${IMAGE}.tar.gz
+          tar -zxf ${BUILD_ID}_${IMAGE}.tar.gz
+          mkdir rootfs
+          sudo mount rootfs.img rootfs
+          sudo tar -cC rootfs . | docker import - ghcr.io/${{ github.repository_owner }}/${IMAGE}
+          sudo umount rootfs
+          docker push ghcr.io/${{ github.repository_owner }}/${IMAGE}:latest


### PR DESCRIPTION
The [tizen-headed-armv7l](https://github.com/orgs/flutter-tizen/packages/container/package/tizen-headed-armv7l) image is currently being built by the [build-docker](https://github.com/flutter-tizen/engine/blob/flutter-3.3.0-tizen/.github/workflows/build-docker.yml) workflow in our engine repo, but I'm planning to use the image in other repos as well (for testing purposes) so it would be better to move the job to this repo.

Other changes include:
- Update actions dependencies.
- Change the BUILD_ID value (from `tizen-unified_20211014.1` to `tizen-unified_20220517.1`).