### PR TITLE
[docker] Include additional packages in tizen-tools image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
     apt-get install -y binutils-arm-linux-gnueabi binutils-aarch64-linux-gnu binutils-i686-linux-gnu && \
+    apt-get install -y git curl pkg-config ca-certificates xz-utils python python3 python3-lib2to3 libncurses5 && \
     apt-get clean
 
 # Copy build results from previous stages.


### PR DESCRIPTION
We're currently using two Docker images for CI engine build:

- [build-engine](https://github.com/orgs/flutter-tizen/packages/container/package/build-engine) ([workflow](https://github.com/flutter-tizen/engine/blob/flutter-3.3.0-tizen/.github/workflows/build-docker.yml))
- [tizen-tools](https://github.com/orgs/flutter-tizen/packages/container/package/tizen-tools) ([workflow](https://github.com/flutter-tizen/tizen_tools/blob/master/.github/workflows/build-docker-image.yml))

but as you can see in the [Dockerfile](https://github.com/flutter-tizen/engine/blob/flutter-3.3.0-tizen/ci/tizen/docker/Dockerfile) of the build-engine image, the image is not very different from the tizen-tools image and it just confuses our maintainers and contributors. Thus I'm planning to remove the build-engine image and only use the tizen-tools image.