### PR TITLE
Allow running build-rootfs.py from outside the git repository

### DIFF
--- a/sysroot/build-rootfs.py
+++ b/sysroot/build-rootfs.py
@@ -149,15 +149,15 @@ parser.add_argument(
     '-o', '--output', metavar='STR', type=str,
     help='name of the output directory (defaults to arch)')
 parser.add_argument(
-    '-c', '--clean', action='store_true',
-    help='clean up the output directory before proceeding')
+    '-f', '--force', action='store_true',
+    help='force re-downloading of packages')
 args = parser.parse_args()
 
 if not args.output:
     args.output = args.arch
 outpath = os.path.abspath(f'{__file__}/../{args.output}')
 
-if args.clean and os.path.exists(outpath):
+if args.force and os.path.exists(outpath):
     shutil.rmtree(outpath)
 
 downloadPath = os.path.join(outpath, '.rpms')

--- a/sysroot/build-rootfs.py
+++ b/sysroot/build-rootfs.py
@@ -228,7 +228,7 @@ subprocess.run(
 # Apply a patch if applicable.
 patchFile = os.path.abspath(f'{__file__}/../{args.arch}.patch')
 if os.path.exists(patchFile):
-    command = f'git apply --directory sysroot/{args.output} {patchFile}'
+    command = f'git apply --unsafe-paths --directory {outpath} {patchFile}'
     subprocess.run(command, shell=True, check=True)
 
 print('Complete')


### PR DESCRIPTION
- Allow running the `build-rootfs.py` script from anywhere even if the current working directory is not this git repository.
- Rename the `--clean` (`-c`) option to `--force` (`-f`) for clarity.